### PR TITLE
edit ch7-2

### DIFF
--- a/docs/kafka/producer-consumer.mdx
+++ b/docs/kafka/producer-consumer.mdx
@@ -290,7 +290,7 @@ CONTAINER ID   IMAGE                             COMMAND                  CREATE
 
 ```bash
 # terminal-command
-docker compose exec broker kafka-topics --create --topic topic-test --bootstrap-server broker:29092 --partitions 1 --replication-factor 1
+docker compose -p part7-naive exec broker kafka-topics --create --topic topic-test --bootstrap-server broker:29092 --partitions 1 --replication-factor 1
 ```
 
 - <var>docker compose exec</var> : 
@@ -331,7 +331,7 @@ docker compose exec broker kafka-topics --create --topic topic-test --bootstrap-
 
 ```bash
 # terminal-command
-docker compose exec broker kafka-topics --describe --topic topic-test --bootstrap-server broker:29092
+docker compose -p part7-naive exec broker kafka-topics --describe --topic topic-test --bootstrap-server broker:29092
 ```
 
 - <var>--describe</var> :  
@@ -370,7 +370,7 @@ docker compose -p part7-naive exec broker /bin/bash
 [appuser@0a0599db4d96 ~]$
 ```
 
-#### 2.2.2 Counsumer 실행
+#### 2.2.2 Consumer 실행
 이후에 `kafka-console-consumer` 를 이용하여 `topic-test` 토픽을 subscribe 합니다.
 
 <CodeDescription>


### PR DESCRIPTION
우선 좋은 가이드 작성해주셔서 감사합니다. 

`07. Kafka - 2) Producer & Consumer`의 [토픽을 작성 & 확인하는 부분](https://mlops-for-mle.github.io/tutorial/docs/kafka/producer-consumer#21-topic)을 수정했습니다.

가이드에 작성된 코드대로 진행하면 
![Pasted image 20230103173905](https://user-images.githubusercontent.com/87639970/210331232-91dc45cb-bfc6-4284-9c52-26311d86ade0.png)
`no configuration file provided: not found` 에러가 발생했습니다.

아래 두 명령어 모두 잘 작동했는데 수정 사항에는 스펙 명세서에 따라 후자를 반영했습니다. 
- `docker exec broker ~~`
- `docker compose -p part7-naive exec broker ~~` <- 반영
